### PR TITLE
Added setup.py for package installation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 *.pyc
+build/
+dist/
+mla.egg-info/

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
-# Machine learning algorithms 
+# Machine learning algorithms
 A collection of minimal and clean implementations of machine learning algorithms.
 
 ### Why?
-This project is targeting people who wants to learn internals of ml algorithms or implement them from scratch.  
-The code is much easier to follow than the optimized libraries and easier to play with.  
+This project is targeting people who wants to learn internals of ml algorithms or implement them from scratch.
+The code is much easier to follow than the optimized libraries and easier to play with.
 All algorithms are implemented in Python, using numpy, scipy and autograd.
 
-### Implemented: 
+### Implemented:
 * [Deep learning (MLP, CNN, RNN, LSTM)] (mla/neuralnet)
 * [Linear regression, logistic regression] (mla/linear_models.py)
 * [Random Forests] (mla/ensemble/random_forest.py)
@@ -21,18 +21,19 @@ All algorithms are implemented in Python, using numpy, scipy and autograd.
 * t-SNE
 * MCMC
 * Word2vec
-* Naive bayes 
+* Naive bayes
 * K-nearest neighbors
 * Adaboost
 * HMM
 
 ### Installation
         git clone https://github.com/rushter/MLAlgorithms
-        cd MLAlgorithms; pip install -r requirements.txt
+        cd MLAlgorithms
+        pip install scipy numpy
+        pip install .
 
 ### How to run examples without relative imports
-        cd MLAlgorithms
-        python -m examples.linear_models
-            
+        python examples/linear_models.py
+
 ### Contributing
 Your contributions are always welcome!

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
 tqdm
-matplotlib==1.5.1
-numpy==1.11.1
-pandas==0.19.0
-scikit-learn==0.18
-scipy==0.18.0
-seaborn==0.7.1
-six==1.10.0
-autograd
+matplotlib>=1.5.1
+numpy>=1.11.1
+pandas>=0.19.0
+scikit-learn>=0.18
+scipy>=0.18.0
+seaborn>=0.7.1
+six>=1.10.0
+autograd>=1.1.7

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,5 @@
+[bdist_wheel]
+universal=1
+
+[metadata]
+description-file=README.md

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,35 @@
+from setuptools import setup, find_packages
+from codecs import open
+from os import path
+
+__version__ = '0.0.1'
+
+here = path.abspath(path.dirname(__file__))
+
+# Get the long description from the README file
+with open(path.join(here, 'README.md'), encoding='utf-8') as f:
+    long_description = f.read()
+
+# get the dependencies and installs
+with open(path.join(here, 'requirements.txt'), encoding='utf-8') as f:
+    all_reqs = f.read().split('\n')
+
+install_requires = [x.strip() for x in all_reqs if 'git+' not in x]
+dependency_links = [x.strip().replace('git+', '') for x in all_reqs if x.startswith('git+')]
+
+setup(
+    name='mla',
+    version=__version__,
+    description='A collection of minimal and clean implementations of machine learning algorithms.',
+    long_description=long_description,
+    url='https://github.com/rushter/mla',
+    download_url='https://github.com/rushter/mla/tarball/' + __version__,
+    license='MIT',
+    packages=find_packages(exclude=['docs', 'tests*']),
+    include_package_data=True,
+    author='Artem Golubin',
+    install_requires=install_requires,
+    setup_requires=['numpy>=1.10', 'scipy>=0.17'],
+    dependency_links=dependency_links,
+    author_email='gh@rushter.com'
+)


### PR DESCRIPTION
I added the setuptools machinery so that  `mla` can now be installed as a regular package by running:

`pip install scipy numpy ; pip install .`

and examples can be run as regular scripts:

`python examples/linar_models.py`

Package can also be installed using 

`python setup.py install`

For now, both scipy and numpy need to be installed before installing mla because of `autograd`. I created a [pull request ](https://github.com/HIPS/autograd/pull/162) to `autograd` so that they remove this (useless) constraint, which would allow to install the package only running:

`pip install .`

Putting the package on PyPI can also be done easily from there.

Hope this helps!