### PR TITLE
fix failing metrics tests under python3.5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 build/
 dist/
 mla.egg-info/
+.cache

--- a/mla/metrics/base.py
+++ b/mla/metrics/base.py
@@ -4,10 +4,10 @@ import numpy as np
 
 
 def check_data(a, b):
-    if isinstance(a, list):
+    if isinstance(a, list) or isinstance(a, range):
         a = np.array(a)
 
-    if isinstance(b, list):
+    if isinstance(b, list) or isinstance(b, range):
         b = np.array(b)
 
     if type(a) != type(b):

--- a/mla/metrics/metrics.py
+++ b/mla/metrics/metrics.py
@@ -60,7 +60,6 @@ def root_mean_squared_log_error(actual, predicted):
 
 def logloss(actual, predicted):
     predicted = np.clip(predicted, EPS, 1 - EPS)
-    predicted /= predicted.sum(axis=1, keepdims=True)
     loss = -np.sum(actual * np.log(predicted))
     return loss / float(actual.shape[0])
 


### PR DESCRIPTION
In the file mla/metrics/test_metrics.py on line 72 the use of range(1, 5) in newer python versions returned a range object instead of a list object, so added detection of range objects to the check_data method where the tests were hitting an error.

Also in that test_metrics.py file, the test_multiclass_logloss case was failing. The change to the logloss function in in metrics.py removes a division that I do not believe is in the multiclass logloss definition. But less confident on that change so looking at it would be appreciated, I just know it now passes all tests for me.

Also added to .gitignore a directory from pytest.