### PR TITLE
add docker configuration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,23 +1,10 @@
-FROM buildpack-deps:trusty
+FROM python:3
 
 RUN mkdir -p /var/app
 WORKDIR /var/app
 COPY . /var/app
 
-# update apt cache
-# install python & python-dev
-# clean up
-# clean up
-# get the pip installer
-# install pip
-# clean up
-# install required pip packages
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends python python-dev && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/ && \
-    wget https://bootstrap.pypa.io/get-pip.py && \
-    python get-pip.py && \
-    rm get-pip.py && \
-    pip install scipy numpy && \
+# install scipy & numpy
+# install required packages
+RUN pip install scipy numpy && \
     pip install .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+FROM buildpack-deps:trusty
+
+RUN mkdir -p /var/app
+WORKDIR /var/app
+COPY . /var/app
+
+# update apt cache
+# install python & python-dev
+# clean up
+# clean up
+# get the pip installer
+# install pip
+# clean up
+# install required pip packages
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends python python-dev && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/ && \
+    wget https://bootstrap.pypa.io/get-pip.py && \
+    python get-pip.py && \
+    rm get-pip.py && \
+    pip install scipy numpy && \
+    pip install .

--- a/README.md
+++ b/README.md
@@ -37,5 +37,11 @@ All algorithms are implemented in Python, using numpy, scipy and autograd.
         cd MLAlgorithms
         python -m examples.linear_models
 
+### How to run examples within Docker
+        cd MLAlgorithms
+        docker build -t mlalgorithms .
+        docker run --rm -it mlalgorithms bash
+        python -m examples.linear_models
+
 ### Contributing
 Your contributions are always welcome!


### PR DESCRIPTION
I like using Docker as a way to work in a disposable environment. I don't have a lot of experience with it, yet, so this might not be the *best* way to go about things.

The configuration I've added allows you to build an image which contains the repository contents and the required software. You can then run a container with that image & have it run `bash` so you can play around with the different examples from a bash shell within the container.

It's completely understandable if this isn't something you want to maintain. If that's the case, feel free to rejected the pull request - no problems! 😃 