### PR TITLE
Fix the CD-1 training code and add comments in RBM

### DIFF
--- a/mla/rbm.py
+++ b/mla/rbm.py
@@ -54,15 +54,18 @@ class RBM(BaseEstimator):
         self.errors = []
 
     def _train(self):
+        '''Use CD-1 training procedure, basically an exact inference for `positive_associations`, 
+        followed by a "non burn-in" block Gibbs Sampling for the `negative_associations`.'''
 
         for i in range(self.max_epochs):
             error = 0
             for batch in batch_iterator(self.X, batch_size=self.batch_size):
                 positive_hidden = sigmoid(np.dot(batch, self.W) + self.bias_h)
-                hidden_states = self._sample(positive_hidden)
+                hidden_states = self._sample(positive_hidden) # sample hidden state h1
                 positive_associations = np.dot(batch.T, positive_hidden)
 
                 negative_visible = sigmoid(np.dot(hidden_states, self.W.T) + self.bias_v)
+                negative_visible = self._sample(negative_visible) # use the samped hidden state h1 to sample v1
                 negative_hidden = sigmoid(np.dot(negative_visible, self.W) + self.bias_h)
                 negative_associations = np.dot(negative_visible.T, negative_hidden)
 


### PR DESCRIPTION
Hi rushter,

I read your RBM implementation, and I got a little confused at the first sight (though I think I've understand the algorithm).

Some fix:
1. `negative_visible` should also be sampled, only the last hidden can use the expectation. Though trivial modification, it follows the original algorithm, and theorically it should also be done (refer to Kevin Murphy's MLaPP P944).
2. Some comments are added in the code, for more friendly reading. At the first sight I didn't find it's CD :)

Thanks.