### PR TITLE
Fix for Numeric Overflow of `softplus` implementation

### DIFF
--- a/mla/neuralnet/activations.py
+++ b/mla/neuralnet/activations.py
@@ -22,7 +22,8 @@ def linear(z):
 
 def softplus(z):
     """Smooth relu."""
-    return np.log(1 + np.exp(z))
+    # Avoid numerical overflow by put possible inf into denominator
+    return z + np.log(1 + 1 / np.exp(z))
 
 
 def softsign(z):

--- a/mla/neuralnet/activations.py
+++ b/mla/neuralnet/activations.py
@@ -22,7 +22,7 @@ def linear(z):
 
 def softplus(z):
     """Smooth relu."""
-    # Avoid numerical overflow by put possible inf into denominator
+    # Avoid numerical overflow by putting possible inf into denominator position
     return z + np.log(1 + 1 / np.exp(z))
 
 


### PR DESCRIPTION
Current softplus implementation is:
```
def softplus(z):
    return np.log(1 + np.exp(z))
```
This could overflow to `inf` if elements in z are large. For example:
```
softplus(1.0e10) # inf
```

Fix is use the following:
```
def softplus2(z):
    return z + np.log(1 + 1 / np.exp(z))
```
By putting potentially large `np.exp(z)` as denominator, expression `1 / np.exp(z)` will be zero if that happens, whole expression still evaluates to correct result: `lim softplus(z) = z` as `z -> inf`. For example:
```
softplus2(1.0e10) # 1.0e10
```
Analytically:
```
z + np.log(1 + 1 / np.exp(z)) 
  = np.log(np.exp(z)) + np.log(1 + 1 / np.exp(z)) 
  = np.log(np.exp(z) * (1 + 1 / np.exp(z))
  = np.log(np.exp(z) + 1)
```
Is equivalent to original formula.
