### PR TITLE
Fix softplus overflow (attempt 2)

### DIFF
--- a/mla/neuralnet/activations.py
+++ b/mla/neuralnet/activations.py
@@ -22,8 +22,9 @@ def linear(z):
 
 def softplus(z):
     """Smooth relu."""
-    # Avoid numerical overflow by putting possible inf into denominator position
-    return z + np.log(1 + 1 / np.exp(z))
+    # Avoid numerical overflow, see:
+    # https://docs.scipy.org/doc/numpy/reference/generated/numpy.logaddexp.html
+    return np.logaddexp(0.0, z)
 
 
 def softsign(z):

--- a/mla/neuralnet/tests/test_activations.py
+++ b/mla/neuralnet/tests/test_activations.py
@@ -9,6 +9,9 @@ def test_softplus():
     # 1.0 / np.exp(z_min) will overflow
     z_min = np.log(sys.float_info.min) - 1.0e10
     inputs = np.array([0.0, 1.0, -1.0, z_min, z_max])
+    # naive implementation of np.log(1 + np.exp(z_max)) will overflow
+    # naive implementation of z + np.log(1 + 1 / np.exp(z_min)) will
+    # throw ZeroDivisionError
     outputs = np.array([0.69314718,  1.31326169,  0.31326169, 0.0, z_max])
 
     assert np.array_equal(outputs, softplus(inputs))

--- a/mla/neuralnet/tests/test_activations.py
+++ b/mla/neuralnet/tests/test_activations.py
@@ -1,0 +1,16 @@
+import sys
+import numpy as np
+
+from mla.neuralnet.activations import *
+
+def test_softplus():
+    # np.exp(z_max) will overflow
+    z_max = np.log(sys.float_info.max) + 1.0e10
+    # 1.0 / np.exp(z_min) will overflow
+    z_min = np.log(sys.float_info.min) - 1.0e10
+    inputs = np.array([0.0, 1.0, -1.0, z_min, z_max])
+    outputs = np.array([0.69314718,  1.31326169,  0.31326169, 0.0, z_max])
+
+    assert np.array_equal(outputs, softplus(inputs))
+
+

--- a/mla/neuralnet/tests/test_activations.py
+++ b/mla/neuralnet/tests/test_activations.py
@@ -12,8 +12,16 @@ def test_softplus():
     # naive implementation of np.log(1 + np.exp(z_max)) will overflow
     # naive implementation of z + np.log(1 + 1 / np.exp(z_min)) will
     # throw ZeroDivisionError
+    outputs = np.array([
+      np.log(2.0),
+      np.log1p(np.exp(1.0)),
+      np.log1p(np.exp(-1.0)),
+      0.0,
+      z_max
+    ])
+
     outputs = np.array([0.69314718,  1.31326169,  0.31326169, 0.0, z_max])
 
-    assert np.array_equal(outputs, softplus(inputs))
+    assert np.allclose(outputs, softplus(inputs))
 
 

--- a/mla/neuralnet/tests/test_activations.py
+++ b/mla/neuralnet/tests/test_activations.py
@@ -20,8 +20,6 @@ def test_softplus():
       z_max
     ])
 
-    outputs = np.array([0.69314718,  1.31326169,  0.31326169, 0.0, z_max])
-
     assert np.allclose(outputs, softplus(inputs))
 
 


### PR DESCRIPTION
Sorry for another PR of the same issue (previously #30).

Last fix will actual causing divide by 0 runtime exception, when input `z` is "negative" enough:
```
def softplus(z):
    return z + np.log(1 + 1 / np.exp(z))
```
For some reason, the toy example I was playing around had only large positive numbers, and only surfaced problems in on direction. Today after looking at the code, I realized the above problem.

Did some digging (checking Tensorflow's implementation, [here](https://github.com/tensorflow/tensorflow/blob/754048a0453a04a761e112ae5d99c149eb9910dd/tensorflow/core/kernels/softplus_op.h#L29), `numpy.logaddexp` is mentioned in the comments. [`logaddexp(x1, x2)`](https://docs.scipy.org/doc/numpy/reference/generated/numpy.logaddexp.html) computes `log(exp(x1) + exp(x2))` and takes care of potentially overflow in `np.exp`. So updated fix is to utilize that:
```
def softplus(z):
    return np.logaddexp(0, z)
```
And:
```
np.logaddexp(0.0, 1.0e10) == 1.0e10
np.logaddexp(0,0, -1.0e10) == 0.0 
```
Also added a unit test for this.

From numpy docs:
**logaddexp**
> Logarithm of the sum of exponentiations of the inputs.

> Calculates `log(exp(x1) + exp(x2))`. This function is useful in statistics where the calculated probabilities of events may be so small as to exceed the range of normal floating point numbers. In such cases the logarithm of the calculated probability is stored. This function allows adding probabilities stored in such a fashion.

