### PR TITLE
Add Leaky ReLU activation function.

### DIFF
--- a/mla/neuralnet/activations.py
+++ b/mla/neuralnet/activations.py
@@ -39,6 +39,10 @@ def relu(z):
     return np.maximum(0, z)
 
 
+def leakyrelu(z, a=0.01):
+    return np.maximum(z * a, z)
+
+
 def get_activation(name):
     """Return activation function by name"""
     try:


### PR DESCRIPTION
Differentiation with autograd package confirmed to work correctly.

Leaky ReLU features a hyperparameter. The current framework set up does not seem to accommodate hyperparameters in activation functions, but the default of 0.01 should suffice for most situations in the meantime. 

See https://towardsdatascience.com/activation-functions-b63185778794 for explanation.