### PR TITLE
bug fix env.close()

### DIFF
--- a/mla/rl/dqn.py
+++ b/mla/rl/dqn.py
@@ -141,3 +141,4 @@ class DQN(object):
                 if done:
                     break
             logger.info('Episode: %s, reward %s' % (i, total_reward))
+        self.env.close()


### PR DESCRIPTION
Exception ignored in: <function Monitor.__del__ at 0x10b1c8bf8>
Traceback (most recent call last):
  File ".../lib/python3.7/site-packages/gym/wrappers/monitor.py", line 233, in __del__
  File ".../lib/python3.7/site-packages/gym/wrappers/monitor.py", line 134, in close
  File ".../lib/python3.7/site-packages/gym/core.py", line 248, in close
  File ".../lib/python3.7/site-packages/gym/core.py", line 248, in close
  File ".../lib/python3.7/site-packages/gym/envs/classic_control/cartpole.py", line 192, in close
  File ".../lib/python3.7/site-packages/gym/envs/classic_control/rendering.py", line 62, in close
  File ".../lib/python3.7/site-packages/pyglet/window/cocoa/__init__.py", line 281, in close
  File ".../lib/python3.7/site-packages/pyglet/window/__init__.py", line 770, in close
TypeError: 'NoneType' object is not callable