### PR TITLE
Fixed a bug in decision tree's _calculate_leaf_value method

### DIFF
--- a/examples/random_forest.py
+++ b/examples/random_forest.py
@@ -1,8 +1,11 @@
+from timeit import default_timer
+start = default_timer()
 import logging
 
-from sklearn.datasets import make_classification
+import numpy as np
+from sklearn.datasets import make_classification, load_boston, load_digits, load_breast_cancer, load_iris
 from sklearn.datasets import make_regression
-from sklearn.metrics import roc_auc_score
+from sklearn.metrics import roc_auc_score, accuracy_score
 
 try:
     from sklearn.model_selection import train_test_split
@@ -20,13 +23,15 @@ def classification():
     X, y = make_classification(
         n_samples=500, n_features=10, n_informative=10, random_state=1111, n_classes=2, class_sep=2.5, n_redundant=0
     )
+    #X,y = load_breast_cancer(return_X_y=True)   
 
     X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.15, random_state=1111)
 
-    model = RandomForestClassifier(n_estimators=10, max_depth=4)
+    model = RandomForestClassifier(n_estimators=5, max_depth=4)
     model.fit(X_train, y_train)
-    predictions = model.predict(X_test)[:, 1]
-    # print(predictions)
+    predictions = model.predict(X_test)[:,1]
+    #predictions = np.argmax(model.predict(X_test),axis=1)
+    print(predictions.shape)
     print("classification, roc auc score: %s" % roc_auc_score(y_test, predictions))
 
 
@@ -46,3 +51,5 @@ def regression():
 if __name__ == "__main__":
     classification()
     # regression()
+    end = default_timer()
+    print(end-start)

--- a/examples/random_forest.py
+++ b/examples/random_forest.py
@@ -1,9 +1,7 @@
-from timeit import default_timer
-start = default_timer()
 import logging
 
 import numpy as np
-from sklearn.datasets import make_classification, load_boston, load_digits, load_breast_cancer, load_iris
+from sklearn.datasets import make_classification
 from sklearn.datasets import make_regression
 from sklearn.metrics import roc_auc_score, accuracy_score
 
@@ -23,16 +21,17 @@ def classification():
     X, y = make_classification(
         n_samples=500, n_features=10, n_informative=10, random_state=1111, n_classes=2, class_sep=2.5, n_redundant=0
     )
-    #X,y = load_breast_cancer(return_X_y=True)   
 
     X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.15, random_state=1111)
 
-    model = RandomForestClassifier(n_estimators=5, max_depth=4)
+    model = RandomForestClassifier(n_estimators=10, max_depth=4)
     model.fit(X_train, y_train)
-    predictions = model.predict(X_test)[:,1]
-    #predictions = np.argmax(model.predict(X_test),axis=1)
-    print(predictions.shape)
-    print("classification, roc auc score: %s" % roc_auc_score(y_test, predictions))
+
+    predictions_prob = model.predict(X_test)[:, 1]
+    predictions = np.argmax(model.predict(X_test), axis=1)
+    #print(predictions.shape)
+    print("classification, roc auc score: %s" % roc_auc_score(y_test, predictions_prob))
+    print("classification, accuracy score: %s" % accuracy_score(y_test, predictions))
 
 
 def regression():
@@ -51,5 +50,3 @@ def regression():
 if __name__ == "__main__":
     classification()
     # regression()
-    end = default_timer()
-    print(end-start)

--- a/mla/ensemble/random_forest.py
+++ b/mla/ensemble/random_forest.py
@@ -39,6 +39,7 @@ class RandomForest(BaseEstimator):
         self._train()
 
     def _train(self):
+        n_classes = None if self.trees[0].regression else len(np.unique(self.y))
         for tree in self.trees:
             tree.train(
                 self.X,
@@ -46,6 +47,7 @@ class RandomForest(BaseEstimator):
                 max_features=self.max_features,
                 min_samples_split=self.min_samples_split,
                 max_depth=self.max_depth,
+                n_classes=n_classes
             )
 
     def _predict(self, X=None):
@@ -78,10 +80,14 @@ class RandomForestClassifier(RandomForest):
         for i in range(X.shape[0]):
             row_pred = np.zeros(y_shape)
             for tree in self.trees:
-                row_pred += tree.predict_row(X[i, :])
+                tmp = tree.predict_row(X[i, :])
+                print(tmp,row_pred.shape,row_pred)
+                row_pred += tmp
+
 
             row_pred /= self.n_estimators
             predictions[i, :] = row_pred
+            print(f"i={i},{row_pred}\n")
         return predictions
 
 

--- a/mla/ensemble/random_forest.py
+++ b/mla/ensemble/random_forest.py
@@ -39,15 +39,13 @@ class RandomForest(BaseEstimator):
         self._train()
 
     def _train(self):
-        n_classes = None if self.trees[0].regression else len(np.unique(self.y))
         for tree in self.trees:
             tree.train(
                 self.X,
                 self.y,
                 max_features=self.max_features,
                 min_samples_split=self.min_samples_split,
-                max_depth=self.max_depth,
-                n_classes=n_classes
+                max_depth=self.max_depth
             )
 
     def _predict(self, X=None):

--- a/mla/ensemble/random_forest.py
+++ b/mla/ensemble/random_forest.py
@@ -80,14 +80,10 @@ class RandomForestClassifier(RandomForest):
         for i in range(X.shape[0]):
             row_pred = np.zeros(y_shape)
             for tree in self.trees:
-                tmp = tree.predict_row(X[i, :])
-                print(tmp,row_pred.shape,row_pred)
-                row_pred += tmp
-
+                row_pred += tree.predict_row(X[i, :])
 
             row_pred /= self.n_estimators
             predictions[i, :] = row_pred
-            print(f"i={i},{row_pred}\n")
         return predictions
 
 

--- a/mla/ensemble/tree.py
+++ b/mla/ensemble/tree.py
@@ -20,7 +20,7 @@ class Tree(object):
         self.outcome = None
         self.criterion = criterion
         self.loss = None
-        self.n_classes = n_classes  #Only for classification
+        self.n_classes = n_classes  # Only for classification
 
         self.left_child = None
         self.right_child = None
@@ -130,7 +130,7 @@ class Tree(object):
         if loss is not None:
             self.loss = loss
 
-        if self.regression==False:
+        if not self.regression:
             self.n_classes = len(np.unique(target['y']))
 
         self._train(X, target, max_features=max_features, min_samples_split=min_samples_split,

--- a/mla/ensemble/tree.py
+++ b/mla/ensemble/tree.py
@@ -65,7 +65,7 @@ class Tree(object):
         return max_col, max_val, max_gain
 
     def train(self, X, target, max_features=None, min_samples_split=10, max_depth=None, 
-                minimum_gain=0.01, loss=None, n_classes=None):
+                minimum_gain=0.01, loss=None, n_classes=2):
         """Build a decision tree from training set.
 
         Parameters
@@ -85,7 +85,7 @@ class Tree(object):
             Minimum gain required for splitting.
         loss : function, default None
             Loss function for gradient boosting.
-        n_classes : int or None
+        n_classes : int
             No of unique labels in case of classification
         """
 

--- a/mla/ensemble/tree.py
+++ b/mla/ensemble/tree.py
@@ -65,7 +65,7 @@ class Tree(object):
         return max_col, max_val, max_gain
 
     def train(self, X, target, max_features=None, min_samples_split=10, max_depth=None, 
-                minimum_gain=0.01, loss=None, n_classes = None):
+                minimum_gain=0.01, loss=None, n_classes=None):
         """Build a decision tree from training set.
 
         Parameters
@@ -85,7 +85,7 @@ class Tree(object):
             Minimum gain required for splitting.
         loss : function, default None
             Loss function for gradient boosting.
-        n_classes : int, default None
+        n_classes : int or None
             No of unique labels in case of classification
         """
 
@@ -143,7 +143,6 @@ class Tree(object):
                 self.outcome = np.mean(targets["y"])
             else:
                 # Probability for classification task
-                #self.outcome = stats.itemfreq(targets["y"])[:, 1] / float(targets["y"].shape[0])
                 self.outcome = np.bincount(targets["y"], minlength=n_classes) / targets["y"].shape[0]
 
     def predict_row(self, row):


### PR DESCRIPTION
I discovered the bug in DT while trying to make RF support multi-class classification. Current code uses `stats.itemfreq`, which will provide misleading result when all labels are same. 

```
y = [1,1,1,1,1] 
print(print(stats.itemfreq(y)[:,1]/len(y)))
```
Which outputs: `[1.]`, while the expected output is `[0,1.0]` for binary classification, or `[0,1.0,0]` for 3  unique labels and so on. 

In this PR's approach, no of unique classes is computed once at root node and shared among all descendants. This automatically enables support for multi-class classification in RF, 